### PR TITLE
Added short delay before trying to reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/*
 .DS_Store
 npm-debug.log
+.idea

--- a/lib/phidgets.js
+++ b/lib/phidgets.js
@@ -28,6 +28,7 @@ phidgets.prototype.defaults = function(){
     password:         null,
     delimiter:        '\r\n',
     readyWaitTimeout: 200,
+    reconnectTimeout: 2000
   }
 }
 
@@ -35,27 +36,31 @@ phidgets.prototype.connect = function(next){
   var self = this;
 
   self.emit('state', 'connecting');
-  
+
   self.client = net.createConnection(self.options.port, self.options.host, function(){
     self.client.setEncoding('utf8');
     self.client.setKeepAlive("enable", 10000);
 
-    self.client.on('end',   self.handleConnectionEnd);
-    self.client.on('close', self.handleConnectionEnd);
+    self.client.on('end',   function() {
+      self.handleConnectionEnd(self, next);
+    });
+    self.client.on('close', function() {
+      self.handleConnectionEnd(self, next);
+    });
     self.client.on('error', function(e){
       self.emit('error', e);
     });
-    self.client.on('data',  function(d){ 
+    self.client.on('data',  function(d){
       self.handleData(d, self);
     });
-    
+
     self.connectWaitTimer = setTimeout(self.checkReady, self.options.readyWaitTimeout, next, self);
 
     self.client.write("995 authenticate, version=" + self.options.version + self.options.delimiter);
     self.client.write("report 8 report" + self.options.delimiter);
     self.client.write("set /PCK/Client/0.0.0.0/1/PhidgetInterfaceKit=\"Open\" for session" + self.options.delimiter);
     self.client.write("listen /PSK/PhidgetInterfaceKit lid0" + self.options.delimiter);
-  }); 
+  });
 };
 
 phidgets.prototype.checkReady = function(next, self){
@@ -79,15 +84,16 @@ phidgets.prototype.quit = function(){
   self.client.write("quit\r\n");
 };
 
-phidgets.prototype.handleConnectionEnd = function(){
-  var self = this;
-  
+phidgets.prototype.handleConnectionEnd = function(self, next){
+
+  self.client.removeAllListeners(['end', 'close', 'error', 'data']);
+  clearTimeout(self.connectWaitTimer);
+  self.client.destroy();
+
   self.ready = false;
   self.emit('state', 'disconnected');
   if(self.shouldReconnect === true){
-    self.connect();
-  }else{
-    // nothing to do
+    setTimeout(function() {self.connect(next);}, self.options.reconnectTimeout);
   }
 };
 
@@ -139,7 +145,7 @@ phidgets.prototype.handleData = function(chunk, self){
       var boardId   = parseInt(pathParts[4]);
       var type      = pathParts[5];
       var number    = parseInt(pathParts[6]);
-      var value     = parseInt(words[8].replace('"',"")); 
+      var value     = parseInt(words[8].replace('"',""));
 
       if(self.ids.indexOf(boardId) < 0){
         self.ids.push(boardId);
@@ -159,7 +165,7 @@ phidgets.prototype.handleData = function(chunk, self){
       } else if(type == "Output"){
         self.data[boardId].outputs[number] = value;
         self.emit("output", boardId, number, value);
-      } 
+      }
 
     }else if(words[0] === '994'){
       self.emit('error', line);

--- a/lib/phidgets.js
+++ b/lib/phidgets.js
@@ -28,7 +28,7 @@ phidgets.prototype.defaults = function(){
     password:         null,
     delimiter:        '\r\n',
     readyWaitTimeout: 200,
-    reconnectTimeout: 2000
+    reconnectionDelay: 200
   }
 }
 
@@ -93,7 +93,7 @@ phidgets.prototype.handleConnectionEnd = function(self, next){
   self.ready = false;
   self.emit('state', 'disconnected');
   if(self.shouldReconnect === true){
-    setTimeout(function() {self.connect(next);}, self.options.reconnectTimeout);
+    setTimeout(function() {self.connect(next);}, self.options.reconnectionDelay);
   }
 };
 


### PR DESCRIPTION
Hello Evan! While playing with the library, I stumbled upon an issue: reloading the page would sometimes prevent the library from successfully connecting (or reconnecting) to the board. It basically threw it into a spiralling death loop... Adding a short (200ms) delay before it tries to reconnect solved the problem for me. While doing so, I also added a bit of cleanup code to the `handleConnectionEnd()` function. Hopefully you can merge it in. Cheers!